### PR TITLE
Add a "Jump To Message" button

### DIFF
--- a/src/commands/starboard/showStars.js
+++ b/src/commands/starboard/showStars.js
@@ -77,7 +77,7 @@ class ShowStarsCommand extends Command {
 			}
 
 			const emoji = Starboard.getEscapedStarEmoji(topStar.starCount);
-			embed.addField('Top Star', `${emoji} ${topStar.starCount} (${topStar.messageID})`, true)
+			embed.addField('Top Star', `${emoji} ${topStar.starCount} (${msg ? `[Jump To](${msg.url})` : topStar.messageID}))`, true)
 				.addField('Channel', `<#${topStar.channelID}>`, true);
 
 			if (content) {


### PR DESCRIPTION
Adds a Jump To button like the ones displayed in starboard embeds when displaying a user's top stars, instead of just the message ID.

![image](https://user-images.githubusercontent.com/16544254/53386143-07594000-394f-11e9-88f5-486297729b25.png)
